### PR TITLE
Checking integration and precursor m/z values for known compounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@ Semi-automated generation of reference spectral libraries from QTOF data
 
 This folder contains the following files:
 
--   " qtof_preprocessing.qmd" : where we upload and analyse the data with the xcms treatment.
+-   "qtof_preprocessing.qmd" : where we upload and analyse the data with the xcms treatment.
+
+-   "qtof_precursormass_accuracy.qmd" : where we inspect the accuracy of reported and predicted precursor masses of spectra in the XcmsExperiment object, by comparing them to theoretical m/z values of known compounds, previously detected in similar samples.
 
 -   "qtof_filtering.qmd" : in this file we filtered the qtof data and we kept just one spectrum per feature and we load the resulting object as "qtof_filtered.RData".
 
     **The execution order:**
 
     1.  " qtof_preprocessing.qmd"
-    2.  "qtof_filtering.qmd"
+    2.  "qtof_precursormass_accuracy.qmd"
+    3.  "qtof_filtering.qmd"

--- a/qtof-preprocessing.qmd
+++ b/qtof-preprocessing.qmd
@@ -69,7 +69,7 @@ The following code my help to create the table with data files and sample names:
 data_file <- list.files(path="./data/mzml",pattern="mzML")
 sample_name <-sub(data_file,  pattern=".mzML", replacement = "")
 sample_id <- substr(sample_name,1,4)
-sample_data <- data.frame(data_file,sample_name)
+sample_data <- data.frame(data_file, sample_id, sample_name)
 write.csv(sample_data, "./data/sample_data/qtof_data_files.csv", row.names=FALSE)
 ```
 
@@ -89,13 +89,11 @@ msLevel(spectra(qtof)) |>
     table()
 ```
 
-# Data evaluation
-
-## General data overview
+# Data evaluation and Retention Time Range Setting
 
 We next aim to get a closer look into the data, ideally extracting signal for individual ions (of a certain compound present in the sample) that will help us defining the settings for the chromatographic peak detection. In particular, we would like to know the width in retention time dimension, that will depend on the liquid chromatography (LC) settings used for the present data set. Without prior knowledge of the data, we need to try to find some signal to look at. We first extract the BPC of our data.
 
-First we assign to each unique sample a unique color :
+First we assign to **each unique sample a unique color** :
 
 ```{r}
 library(RColorBrewer)
@@ -108,7 +106,7 @@ names(col_sample_id) <- c("blank", "S1Ra", "S1Rb", "S1Rc", "S9Ra",
 col_sample <- col_sample_id[sample_data$sample_id]
 ```
 
-then we plot the base peak chromatogram of this data :
+Then we plot the **base peak chromatogram** for all samples :
 
 ```{r}
 bpc <- chromatogram(qtof, aggregationFun = "max")
@@ -119,9 +117,9 @@ legend("topright", legend = names(col_sample_id), lty = 1, col = col_sample_id)
 grid()
 ```
 
-The base peak chromatography of this data shows that most of the signal is detected before 900 seconds, and after 1300 seconds noise seems to increase.
+The base peak chromatogram shows that most of the signal is detected before 900 seconds, and after 1300 seconds noise seems to increase.
 
-We next clean the data set filtering to a retention time range of 10-900 seconds (we remove the first couple of seconds because we don't expect LC-separation there). With the newly converted MS data, we no longer need to filter 0-intensity peaks and empty spectra. Below we list the number of MS1 and MS2 spectra for the filtered data set.
+We next clean the data set **filtering to a retention time range of 10-900 seconds** (we remove the first couple of seconds because we don't expect LC-separation there). Because the QTOF data were converted from Waters raw files were converted into `.mzML` files (**MSConvert** from **ProteoWizard**), with the `Waters DDA Processing` filter enabled, the Lockmass scans are already filtered out and we no longer need to filter 0-intensity peaks and empty spectra. Below we list the numbers of MS1 and MS2 spectra for the filtered data set.
 
 ```{r}
 qtof <- filterSpectra(qtof, filterRt, c(10, 1000))
@@ -131,7 +129,7 @@ spectra(qtof) |>
 
 ```
 
-We next extract a total ion chromatogram (TIC) and base peak chromatogram (BPC) and calculate the similarities between these to evaluate similarity in the performance of the liquid chromatography. To this end we first bin the signal along retention time axis into 45 second wide bins (to get \~ 20 bins along the retention time). After log2 transforming the binned intensities, we center them for each bin across samples. This data set represents thus, for each bin, the relative intensity measured in one sample compared to the average for that bin across all samples.
+We next extract a total ion chromatogram (TIC) and base peak chromatogram (BPC) and calculate the similarities between these to evaluate similarity in the performance of the liquid chromatography. To this end we first **bin the signal along the retention time axis** into 45 second wide bins (to get \~ 20 bins along the retention time). After log2 transforming the binned intensities, we center them for each bin across samples. This data set represents thus, **for each bin, the relative intensity measured in one sample compared to the average for that bin across all samples**.
 
 ```{r}
 #' Extract TIC
@@ -151,7 +149,7 @@ rownames(ticmap) <- sampleData(qtof)$sample_name
 ticmap <- scale(ticmap, center = TRUE, scale = FALSE)
 ```
 
-We next a hierarchical clustering approach to group the samples (rows) based on the signal along the retention time axis and create a heatmap of the relative signal per bin. This allows us to eventually spot the area along the retention time in which the individual LC runs are similar/different.
+We next use a **hierarchical clustering** approach to group the samples (rows) based on the signal along the retention time axis and create a heatmap of the relative signal per bin. This allows us to eventually **spot the area along the retention time in which the individual LC runs are similar/different**.
 
 ```{r}
 ann <- data.frame(sample_id = sampleData(qtof)[, "sample_id"])
@@ -162,10 +160,12 @@ pheatmap(ticmap, cluster_cols = FALSE,
          annotation_row = ann)
 ```
 
-LC-runs separate by seed types. There is also some grouping of the replicated measurement runs for each sample. The biggest difference in the TIC seems to be around 302 seconds. We repeat the analysis using the base peak chromatogram (BPC).
+LC-runs separate by seed types. There is also some grouping of the replicated measurement runs for each sample. The biggest difference in the TIC seems to be around 302 seconds.
+
+We repeat the analysis using the base peak chromatogram (BPC).
 
 ```{r}
-#' Extract TIC
+#' Extract BPC
 bpc <- chromatogram(qtof, aggregationFun = "max")
 #' Bin the signal
 bpcb <- bin(bpc, binSize = 45)
@@ -194,13 +194,13 @@ plot(bpc, col = paste0(col_sample, 40), main = "BPC")
 grid()
 ```
 
-Note however that the TIC and BPC was created on the raw data and there seem to be relatively big retention time shifts between the samples. We will thus repeat the same analysis after the retention time alignment step.
+Note however that the TIC and BPC were created on the raw data and there seems to be relatively big retention time shifts between the samples. We will thus repeat the same analysis after the retention time alignment step.
 
 # Data preprocessing
 
 To derive the settings for the chromatographic peak detection for the present data set we below extract the ion signal for a m/z range which might contain signal from some ions. Definition of this m/z range is described in [raw-data-evaluation.qmd](raw-data-evaluation.qmd).
 
-Below we extract the ion chromatogram for one example m/z range.
+Below we extract the ion chromatogram for one example m/z range. The following m/z range encompasses m/z 449.1078, corresponding to dihydrokaempferol glucoside \[M-H\]-, a compound detected in a previous experiment in flaxseed integuments.
 
 ```{r}
 mzr <- c(449.08, 449.12)
@@ -217,9 +217,43 @@ plot(a, col = paste0(col_sample, 80), xlim = c(230, 300))
 grid()
 ```
 
-We can see a shift in retention time between samples. Generally, the observed peaks seem to be between 10-15 seconds wide. We thus specify for the peak detection step below a `peakwidth = c(8, 20)`. This setting yielded acceptable results (tested in [raw-data-evaluation.qmd](raw-data-evaluation.qmd)).
+We can see a shift in retention time between samples. Generally, the observed peaks seem to be between 10-15 seconds wide.
 
-We next perform the chromatographic peak detection using the *centWave* algorithm. With `integrate = 2` we use an alternative algorithm to correctly identify the boundaries of the identified chromatographic peaks. Parameter `chunkSize` is used to control the number of files from which the data should be loaded into memory at a time.
+Below we extract the ion chromatogram for two m/z ranges corresponding to previously characterized compounds that eluted last of all characterized compounds in earlier LC-MS analyses of flaxseed integuments: m/z 1248.8553 - high MW Herbacetin diglucoside derivative m/z 869.2592 - triacetyl Herbaectin diglucoside conjugate We will check if these compounds fall in the selected retention time range (10-1000 s), and if the peak width is similar to the peak width observed for m/z 449.
+
+```{r}
+mzr <- c(869.24, 869.28)
+
+b <- chromatogram(qtof, mz = mzr, aggregationFun = "max")
+plot(b, col = paste0(col_sample, 80))
+grid()
+```
+
+To better see the peak width, we focus on a retention time range 900-1000.
+
+```{r}
+plot(b, col = paste0(col_sample, 80), xlim = c(900, 1000))
+grid()
+```
+
+```{r}
+mzr <- c(1248.83, 1248.87)
+
+b <- chromatogram(qtof, mz = mzr, aggregationFun = "max")
+plot(b, col = paste0(col_sample, 80))
+grid()
+```
+
+To better see the peak width, we focus on retention time range 900-1000.
+
+```{r}
+plot(b, col = paste0(col_sample, 80), xlim = c(800, 900))
+grid()
+```
+
+All previously characterized LC-MS features fall within the selected retention time range and the peak widths of all inspected features is constant, around 10-15 seconds. We thus specify for the peak detection step below as `peakwidth = c(8, 20)`. This setting yielded acceptable results (tested in [raw-data-evaluation.qmd](raw-data-evaluation.qmd))
+
+We next perform the **chromatographic peak detection** using the *centWave* algorithm. With `integrate = 2` we use an alternative algorithm to correctly identify the boundaries of the identified chromatographic peaks. Parameter `chunkSize` is used to control the number of files from which the data should be loaded into memory at a time.
 
 ```{r}
 qtof <- findChromPeaks(qtof, CentWaveParam(peakwidth = c(8, 20), integrate = 2),
@@ -237,7 +271,7 @@ quantile(unname(pks[, "mzmax"] - pks[, "mzmin"]))
 
 The distribution of chromatographic peak widths in the retention time dimension ranged from approximately 1.64 to 77.27 seconds, with a median of about 12.02 seconds. In the m/z dimension, peak widths were much narrower, ranging from 0 to 0.1055 m/z units, with a median of around 0.0213.
 
-We next perform the chromatographic peak refinement to reduce the number of potential *centWave*-specific peak detection artifacts. We choose settings that depend on the observed peak widths above (i.e. half of the observed average widths).
+We next perform the chromatographic peak refinement to reduce the number of potential *centWave*-specific peak detection artifacts. We choose settings that depend on the observed peak widths above **(i.e. half of the observed average widths)**.
 
 ```{r}
 mnpp <- MergeNeighboringPeaksParam(expandRt = 6, expandMz = 0.01)
@@ -252,7 +286,7 @@ quantile(unname(pks[, "rtmax"] - pks[, "rtmin"]))
 quantile(unname(pks[, "mzmax"] - pks[, "mzmin"]))
 ```
 
-we observe that peak widths had not changed after refinement
+We observe that peak widths have not changed after refinement.
 
 ```{r}
 # Extract chromatographic peaks
@@ -281,6 +315,7 @@ We next perform an initial correspondence analysis that is needed for the subseq
 
 ```{r}
 #' Extract the ion chromatogram again.
+mzr <- c(449.08, 449.12)
 a <- chromatogram(qtof, aggregationFun = "max", mz = mzr)
 
 #' Configure settings;
@@ -315,7 +350,7 @@ With `bw = 6` we are able to separate the two sets of chromatographic peaks into
 qtof <- groupChromPeaks(qtof, param = pdp)
 ```
 
-We next perform the retention time alignment. We will use the *peaks groups* method that adjusts retention times based on the observed retention time (differences) of chromatographic peaks assigned to the same feature. The method performs a retention time-dependent adjustment, i.e. based on the data, each retention time range can be adjusted by a different factor. The *smoothness* can be configured with parameter `span`.
+We next perform the retention time alignment. We will use the *Peak Groups* method that adjusts retention times based on the observed retention time (differences) of chromatographic peaks assigned to the same feature. The method performs a retention time-dependent adjustment, i.e. based on the data, each retention time range can be adjusted by a different factor. The *smoothness* can be configured with parameter `span`.
 
 ```{r}
 pgp <- PeakGroupsParam(
@@ -335,7 +370,7 @@ plotAdjustedRtime(qtof, col = paste0(col_sample, 80))
 grid()
 ```
 
-we can see that the difference between the adjusted and the raw retention time vary between -10 and 10 seconds, that is a large difference, but let's see how it affects the bcp after retention time alignment.
+we can see that the difference between the adjusted and the raw retention time vary between -10 and 10 seconds, that is a large difference, but let's see how it affects the BPC after retention time alignment.
 
 Heatmap and sample clustering based on BPC-signal after retention time alignment.
 
@@ -435,7 +470,7 @@ sum(is.na(featureValues(qtof)))
 head(featureValues(qtof))
 ```
 
-the resulting table shows a lot of "NA" missing values, so let's apply the gap-filling in order to fill in missing peaks.
+The resulting table shows a lot of "NA" missing values, so let's apply the gap-filling in order to fill in missing peaks.
 
 ```{r}
 #' Perform gap-filling
@@ -448,7 +483,7 @@ sum(is.na(featureValues(qtof)))
 head(featureValues(qtof))
 ```
 
-the table above shows that there is no more missing peaks. Some gap-filled signal seems however to be higher than the detected peak signal. We might eventually need to look into that later.
+The table above shows that there is no more missing peaks. Some gap-filled signal seem however to be higher than the detected peak signal. We might eventually need to look into that later.
 
 ```{r}
 #' Save the result object
@@ -460,7 +495,7 @@ load("data/qtof.RData")
 head(featureValues(qtof))
 ```
 
-the extracted ion chromatogram for some knowns compounds :
+The extracted ion chromatogram for some known compounds :
 
 ```{r}
 mzr <- c(287.04, 287.06)
@@ -606,12 +641,16 @@ spectra(qtof)$original_precursor_mz <- precursorMz(spectra(qtof))
 spectra(qtof)$precursorMz <- epmz
 ```
 
-## Questions for discussion with Rebecca
+## Questions and answers
 
--   [ ] What's next? Should we annotate the MS1 features using the MS2 DDA data?
--   [ ] Discuss the observed difference between the observed and expected precursor m/z. What should we trust?
--   [ ] No QC/sample pool data? Should we remove features with high RSD (CV) in the 3 technical replicates?
--   [ ] Discuss the gap filling issue.
+-   What's next?\
+    =\> Annotating the MS1 features: First with adaptation of original Perl script (including heterodimers between neighboring features). Look up also newer available algorithms. Using the MS2 DDA data for improving annotation of MS1 features is a good idea, but not immediately a priority here, unless existing functions or algorithms are available.\
+    =\> aligning qtof negative and ftms negative experiments for flaxseeds based on existing RDynLib scripts.\
+-   Discuss the observed difference between the observed and expected precursor m/z. What should we trust?\
+    =\> In `qtof_precursormass_accuracy.qmd`, I compared the reported and predicted precursor m/z with theoretical m/z of known compounds in the analysis. Clearly predicted m/z values are much closer to the theoretical m/z values (\< 3ppm) and should be trusted.\
+-   No QC/sample pool data? Should we remove features with high RSD (CV) in the 3 technical replicates?\
+    =\> This experiment is a follow-up of a quantitative comparative analysis, set up with the goal to elucidate structurally the compounds present in flaxseed varieties S1 and S9. The purpose is not to compare the two varieties here, but only to generate spectra. No need to discard features.\
+-   Discuss the gap filling issue. =\> Does this indicate a high background (noise) signal? Also here, as the purpose was to generate spectra for compounds in varieties S1 and S9, the quantities or intensities are not so important and no need to worry here.
 
 # Session Information
 

--- a/qtof_precursormass_accuracy.qmd
+++ b/qtof_precursormass_accuracy.qmd
@@ -1,0 +1,206 @@
+---
+title: "Inspect_precursor_mz"
+tbl-cap-location: bottom
+editor: visual
+date: 'Compiled: `r format(Sys.Date(), "%B %d, %Y")`'
+---
+
+# Introduction
+
+Flaxseed integuments of the same varieties as analyzed in the present experiment (S1 and S9), have been previously analyzed by LC-MSn (ftms), and 50 compounds have been identified or partially characterized. For **45** of these compounds a **molecular formula** has been proposed. The m/z values of these compounds have been used as an inclusion list for fragmentation in the present LC-QTOF analyses. The molecular formulas of these compounds are available in an .xlsx file. Here we will evaluate the differences between the **theoretical m/z of the known compounds** and the **reported precursor m/z** and **predicted precursor m/z** of the fragmentation spectra in the LC-QTOF analysis. We will also identify the spectra that correspond to known compounds of the ftms experiment.
+
+# Data import
+
+We first load all required R packages for the analysis in this document.
+
+```{r}
+#| message: false
+
+#' Load required libraries
+library(xcms)
+library(MsExperiment)
+library(Spectra)
+library(readxl)
+library(rcdk)
+library(ggplot2)
+```
+
+Read the table with MS data from known compounds and the XcmsExperiment object created in qtof-preprocessing.qmd
+
+```{r}
+#' Read the table with MS data from known compounds
+pth <- getwd()
+knowns <- read_xlsx(file.path(pth, "data/compound_data/inclusionlist50_fullfragmentation.xlsx")) |>as.data.frame()
+knowns <- knowns[!knowns$charged_Formula=="NA",]
+
+#' Import the XcmsExperiment object
+load("data/qtof.RData")
+qtof
+```
+
+Get the theoretical masses of the known compounds based on their molecular formula. The `charged_Formula` corresponds to \[M-H\] for a single charged compound and to \[M-2H\] for a double charged compound. The charge of the compounds detected in a previous LC-MS experiment is in column `z`.
+
+```{r}
+# Create lists of "charged formula" and charge
+formula.list <- split(knowns$charged_Formula,f=as.factor(1:nrow(knowns)))
+charge.list <- split(knowns$z, f=as.factor(1:nrow(knowns)))
+
+# Combine formula and charge into list of lists
+input.list <- Map(list, formula.list, charge.list)
+
+#create function to extract the m/z value of the charged features 
+get_m.over.z <- function(f,z) {
+  formula <- get.formula(f)
+  monoisotopicmass <- formula@mass
+  m.over.z <- monoisotopicmass/z
+  return(m.over.z)
+}
+
+
+# Apply the get_m.over.z function to each formula-charge pair using lapply
+mzknown <- lapply(input.list, function(x) get_m.over.z(x[[1]], x[[2]]))
+
+# Unlist the result to get a numeric vector
+mzknown <- unlist(mzknown) 
+
+```
+
+```{r}
+#' Extract reported precursor m/z
+pmz <- precursorMz(spectra(qtof))
+pmz_clean <- pmz[!is.na(pmz)]
+#' Estimate precursor m/z
+epmz <- estimatePrecursorMz(spectra(qtof),
+                            tolerance = 0.05, ppm = 20)
+epmz_clean <- epmz[!is.na(epmz)]
+```
+
+The smallest differences between any known compound's monoisotopic m/z and the reported as well as the estimated precursor m/z are listed below:
+
+```{r}
+#' Calculate difference to the reported precursor.
+min_diffs_pmz <- sapply(mz, function(x) {
+  min(abs(x - pmz_clean))
+})
+min_diffs_epmz <- sapply(mz, function(x) {
+  min(abs(x - epmz_clean))
+})
+
+summary(min_diffs_pmz)
+summary(min_diffs_epmz)
+min_diffs_pmz <- min_diffs_pmz[min_diffs_pmz<0.1]
+min_diffs_epmz <- min_diffs_epmz[min_diffs_epmz<0.1]
+boxplot(list(reported = min_diffs_pmz, estimated = min_diffs_epmz),
+        ylab = "difference to theoretical m/z of known features")
+grid(nx = NA, ny = NULL)
+```
+The differences between theoretical m/z values and estimated precursor m/z values are much smaller than between theoretical m/z values and reported precursor m/z value. Now we will have a look at the smallest differences, expressed in parts per million (ppm) for each of the theoretical m/z values.
+
+```{r}
+# Use lapply to calculate ppm differences for each mz
+ppm_diff_list <- lapply(mz, function(m) {
+  ppm <- abs(pmz - m) / m * 1e6         # Compute ppm difference
+  head(sort(ppm), 10)                   # Take 10 smallest
+})
+
+# Name each list element for clarity
+names(ppm_diff_list) <- paste ("mz", sprintf("%.4f", mz))
+
+# Identify mz values where all 10 ppm diffs < 50
+valid_mz <- sapply(ppm_diff_list, function(ppm) all(ppm < 50))
+
+# Filter list to include only those with all < 50 ppm
+low_ppm_list <- ppm_diff_list[valid_mz]
+
+# Report how many mz values passed the filter
+cat("Number of mz values, out of 45 known molecular formulas, with all 10 lowest differences < 50 ppm:", length(low_ppm_list), "\n")
+
+# Reshape for plotting
+library(reshape2)
+ppm_df <- melt(low_ppm_list)
+colnames(ppm_df) <- c("ppm_diff", "theoretical_mz")
+
+ggplot(ppm_df, aes(x = theoretical_mz, y = ppm_diff)) +
+  geom_boxplot(fill = "steelblue") +
+  labs(title = "Reported Precursor m/z: Boxplots of 10 Lowest PPM Differences (<50 ppm)",
+       x = "mz Value",
+       y = "PPM Difference") +
+  theme(axis.text.x = element_text(angle = 90, hjust = 1, size = 6))
+
+```
+Now we do the same for the **estimated precursor m/z values**.
+
+```{r}
+# Use lapply to calculate ppm differences for each mz
+ppm_diff_list <- lapply(mz, function(m) {
+  ppm <- abs(epmz - m) / m * 1e6         # Compute ppm difference
+  head(sort(ppm), 10)                   # Take 10 smallest
+})
+
+# Name each list element for clarity
+names(ppm_diff_list) <- paste ("mz", sprintf("%.4f", mz))
+
+# Identify mz values where all 10 ppm diffs < 50
+valid_mz <- sapply(ppm_diff_list, function(ppm) all(ppm < 50))
+
+# Filter list to include only those with all < 50 ppm
+low_ppm_list <- ppm_diff_list[valid_mz]
+
+# Report how many mz values passed the filter
+cat("Number of mz values, out of 45 known molecular formulas, with all 10 lowest differences < 50 ppm:", length(low_ppm_list), "\n")
+
+# Reshape for plotting
+library(reshape2)
+ppm_df <- melt(low_ppm_list)
+colnames(ppm_df) <- c("ppm_diff", "theoretical_mz")
+
+
+ggplot(ppm_df, aes(x = theoretical_mz, y = ppm_diff)) +
+  geom_boxplot(fill = "steelblue") +
+  labs(title = "Estimated Precursor m/z: Boxplots of 10 Lowest PPM Differences (<50 ppm)",
+       x = "mz Value",
+       y = "PPM Difference") +
+  theme(axis.text.x = element_text(angle = 90, hjust = 1, size = 6))
+
+```
+
+For the **reported precursor m/z values**, the differences with theoretical m/z values are mainly **between 5 and 30 ppm**.  This corresponds to the **resolution of the quadrupole** in which the precurors were selected.
+For the **estiamted precursor m/z values**, the differences with theoretical m/z values are **below 3 ppm**. This corresponds to the **high-resolution Time-of-Flight** measurements of these precursor m/z values.
+There are only 20 boxplots. This might be because certain known compounds had exactly identical theoretical m/z value. We will check this below: 
+
+```{r}
+names(low_ppm_list)
+unique(names(low_ppm_list))
+length(unique(ppm_df$theoretical_mz))
+```
+
+Now we should find to which features in the qtof lc-ms experiment these low ppm differences with respect to known compounds, correspond.
+
+```{r}
+#create spectra data matrix from the  qtof XcmsExperiment object 
+spd <- spectraData(spectra(qtof))
+dim(spd)
+
+# Create theoretical_mz and ppm columns to store the matches with known compounds
+spd$theoretical_mz <- NA_real_
+spd$ppm <- NA_real_
+
+# Assign best match within 3 ppm
+matches <- sapply(epmz, function(p) {
+  ppm_diff <- abs(p - mz) / mz * 1e6
+  if (any(ppm_diff < 3, na.rm = TRUE)) {
+    i <- which.min(ppm_diff)
+    c(mz[i], ppm_diff[i])
+  } else {
+    c(NA, NA)
+  }
+})
+
+sum(!is.na(matches))
+# Store results in spd
+matches <- t(matches)
+spd$theoretical_mz <- matches[,1]
+spd$ppm <- matches[,2]
+
+```
+In the qtof experiment of S1 and S9 flaxseeds, there were 5242 spectra of which the precursor m/z corresponds to one of the 45 known compounds (ppm < 3).


### PR DESCRIPTION
Made changes in `qtof-preprocessing.qmd`:
-Fixed minor typos
-Added EIC plots for m/z ranges corresponding to identified compounds
-Answered the questions at the end of the document

Created `qtof_precursormass_accuracy.qmd`:
This code inspects the accuracy of reported and estimated precursor m/z values with respect to the theoretical m/z values of known compounds. The estiamted precursor m/z values are within 3 ppm from theoretical values.

Added the `qtof_precursormass_accuracy.qmd` in `README.md`.